### PR TITLE
feat: improve protocol

### DIFF
--- a/src/client_loop.py
+++ b/src/client_loop.py
@@ -36,12 +36,12 @@ def step(client_socket, screen, transparent_surface, name_font):
 
 def send_data(client_socket, data):
     data = pickle.dumps(data)
-    data = len(data).to_bytes(4) + data
+    data = len(data).to_bytes(4, "big") + data
     client_socket.sendall(data)
 
 
 def receive_data(client_socket):
-    size = int.from_bytes(client_socket.recv(4))
+    size = int.from_bytes(client_socket.recv(4), "big")
     data = bytearray()
     while len(data) < size:
         chunk = client_socket.recv(size - len(data))


### PR DESCRIPTION
This PR intends to expand the present protocol by adding some extra steps:
1. Initial information sent by the server when a client connects (contains the players per team, identified by their names)
2. Server-side validation of the name (there's no possibility for duplicated names)
3. Server-side validation of the team (in order to keep the teams balanced, there's no possibility of having more than 1 player difference among teams)

The client suffered some improvements in terms of dealing with the new server logic such as the possibility of keep trying until there is a correct name and team choosen! 💪 

Follows an example of utilization:
![image](https://github.com/user-attachments/assets/94973bce-d4db-4310-ac58-fbb5174460fc)
