### PR TITLE
feat: add matches

### DIFF
--- a/src/client_loop.py
+++ b/src/client_loop.py
@@ -250,3 +250,19 @@ def draw_hud(screen, state):
     clock_min_tens = font.render(f"{state.clock // 600}", True, font_color)
     clock_min_tens_pos = clock_min_ones_pos - clock_digit_width
     screen.blit(clock_min_tens, (clock_min_tens_pos + round((clock_digit_width - clock_min_tens.get_width()) / 2), font_pos_y))
+
+    # Desenhar estado da partida
+    minutes = int(state.match_manager.time_remaining) // 60
+    seconds = int(state.match_manager.time_remaining) % 60
+    match_state_text = f"{state.match_manager.state.name.capitalize()}: {minutes:02d}:{seconds:02d}"
+    match_state_surface = font.render(match_state_text, True, font_color)
+
+    # Calcular a posição central do HUD
+    hud_center_x = hud_pos_x + hud_width / 2
+    text_width = match_state_surface.get_width()
+
+    # Ajustar a posição do texto para centralizar
+    text_pos_x = hud_center_x - text_width / 2
+    text_pos_y = font_pos_y
+
+    screen.blit(match_state_surface, (text_pos_x, text_pos_y))

--- a/src/server.py
+++ b/src/server.py
@@ -4,7 +4,7 @@ import pygame
 import pickle
 import readline
 import server_loop as loop
-from state import Player, State, SCREEN_WIDTH, SCREEN_HEIGHT, PLAYER_AREA_HEIGHT, PLAYER_AREA_TL_Y, PLAYER_AREA_BR_X, PLAYER_AREA_TL_X, Team
+from state import Player, State, SCREEN_WIDTH, SCREEN_HEIGHT, PLAYER_AREA_HEIGHT, PLAYER_AREA_TL_Y, PLAYER_AREA_BR_X, PLAYER_AREA_TL_X, Team, MatchManager
 from threading import Condition, Lock, Thread
 from hot_reloading import hot_cycle
 
@@ -49,7 +49,7 @@ def main():
     )
     game_cycle_thread.start()
 
-    interpreter_thread = Thread(target=interpreter, daemon=True)
+    interpreter_thread = Thread(target=interpreter, args=(state,), daemon=True)
     interpreter_thread.start()
 
     with socketserver.ThreadingTCPServer(("0.0.0.0", port), GameTCPHandler) as server:
@@ -73,10 +73,27 @@ def game_cycle(debug, state, clock, inputs, state_lock, send_cond, last_state_pi
             pass
 
 
-def interpreter():
+def interpreter(state):
     while True:
         line = input(">>> ")
-        exec(line)
+        if line.startswith("start_match"):
+            state.match_manager.start_match()
+        elif line.startswith("pause_match"):
+            state.match_manager.pause_match()
+            print("Match paused")
+        elif line.startswith("resume_match"):
+            state.match_manager.resume_match()
+            print("Match resumed")
+        elif line.startswith("set_match_time"):
+            _, seconds = line.split()
+            state.match_manager.set_match_time(int(seconds))
+            print(f"Match time set to {seconds} seconds")
+        elif line.startswith("set_break_time"):
+            _, seconds = line.split()
+            state.match_manager.set_break_time(int(seconds))
+            print(f"Break time set to {seconds} seconds")
+        else:
+            exec(line)
 
 
 MAX_NAME_ATTEMPTS = 3

--- a/src/server_loop.py
+++ b/src/server_loop.py
@@ -2,7 +2,7 @@ import math
 import pickle
 import pygame
 from itertools import combinations, product
-from state import FIELD_WIDTH, PLAYER_AREA_BR_X, PLAYER_AREA_HEIGHT, PLAYER_AREA_TL_X, PLAYER_AREA_TL_Y, Team, FIELD_TL_X, FIELD_TL_Y, FIELD_HEIGHT
+from state import FIELD_WIDTH, PLAYER_AREA_BR_X, PLAYER_AREA_HEIGHT, PLAYER_AREA_TL_X, PLAYER_AREA_TL_Y, Team, FIELD_TL_X, FIELD_TL_Y, FIELD_HEIGHT, MatchManager, MatchState
 
 
 def moving_circles(state):
@@ -11,20 +11,31 @@ def moving_circles(state):
 
 
 def step(state, clock, inputs, state_lock, send_cond, last_state_pickle):
+    dt = clock.tick(60) / 1000.0  # Time since last frame
+
     with state_lock:
-        for address, player in state.players.items():
-            if address in inputs:
-                apply_input(player, inputs[address])
-                del inputs[address]
+        prev_state = state.match_manager.state
+        state.match_manager.update(dt)
+        # Reset scores if match just ended (PLAYING -> BREAK)
+        if prev_state == MatchState.PLAYING and state.match_manager.state == MatchState.BREAK:
+            reset_scores(state)
+            reset_ball(state)
+            reset_players(state)
 
-        for circle in moving_circles(state):
-            update_position(circle)
+        if state.match_manager.state == MatchState.PLAYING:
+            for address, player in state.players.items():
+                if address in inputs:
+                    apply_input(player, inputs[address])
+                    del inputs[address]
 
-        handle_collisions(state)
+            for circle in moving_circles(state):
+                update_position(circle)
 
-        handle_kicks(state)
+            handle_collisions(state)
 
-        check_goal(state)
+            handle_kicks(state)
+
+            check_goal(state)
 
         state.clock = pygame.time.get_ticks() // 1000
 
@@ -35,8 +46,6 @@ def step(state, clock, inputs, state_lock, send_cond, last_state_pickle):
             send_cond.notify_all()
 
         clear_kicks(state)
-
-    clock.tick(60)
 
     return True
 
@@ -242,3 +251,8 @@ def reset_players(state):
         player.vx = 0
         player.vy = 0
         player.kick = False
+
+
+def reset_scores(state):
+    state.score_blue = 0
+    state.score_red = 0

--- a/src/state.py
+++ b/src/state.py
@@ -45,6 +45,7 @@ class State:
         self.score_red: int = 0
         self.score_blue: int = 0
         self.clock: int = 0 # in seconds
+        self.match_manager = MatchManager()
 
 
 class Circle:
@@ -105,3 +106,56 @@ class Post(Circle):
     ) -> None:
         super().__init__(x, y, radius=radius)
         self.team: Team = team
+
+class MatchState(Enum):
+    PLAYING = auto()
+    BREAK = auto()
+    PAUSED = auto()
+
+class MatchManager:
+    def __init__(self):
+        self.state = MatchState.BREAK
+        self.match_duration = 120  # 2 minutos
+        self.break_duration = 30   # 30 segundos
+        self.time_remaining = self.break_duration
+
+    def update(self, dt):
+        if self.state != MatchState.PAUSED:
+            self.time_remaining -= dt
+            if self.time_remaining <= 0:
+                self.time_remaining = 0
+                self._change_state()
+                print(f"State changed to {self.state}")
+
+    def _change_state(self):
+        if self.state == MatchState.PLAYING:
+            self.state = MatchState.BREAK
+            self.time_remaining = self.break_duration
+            print("Match ended, break started")
+        elif self.state == MatchState.BREAK:
+            self.state = MatchState.PLAYING
+            self.time_remaining = self.match_duration
+            print("Break ended, match started")
+        elif self.state == MatchState.PAUSED:
+            self.state = MatchState.PLAYING
+            self.time_remaining = self.match_duration
+            print("Match resumed")
+
+    def start_match(self):
+        if self.state == MatchState.BREAK:
+            self.state = MatchState.PLAYING
+            self.time_remaining = self.match_duration
+
+    def pause_match(self):
+        if self.state == MatchState.PLAYING:
+            self.state = MatchState.PAUSED
+
+    def resume_match(self):
+        if self.state == MatchState.PAUSED:
+            self.state = MatchState.PLAYING
+
+    def set_match_time(self, seconds):
+        self.match_duration = seconds
+
+    def set_break_time(self, seconds):
+        self.break_duration = seconds


### PR DESCRIPTION
This PR introduces a new match state management system and integrates it into both the server and client sides 🎮⚙️

### ✅ Server-side changes:
- Added a `MatchManager` class to encapsulate match logic, with support for:
  - `PLAYING`, `BREAK`, and `PAUSED` states.
  - Automatic state transitions based on a countdown (`match_duration` and `break_duration`).
  - Public control methods: `start_match`, `pause_match`, `resume_match`, `set_match_time`, `set_break_time`.
- Refactored the `interpreter` function to support these new commands directly via CLI.
- Integrated match state updates into the `game_cycle`, ensuring players and objects only update during active gameplay.
- Automatically resets scores, ball, and player positions when a match ends.
  
### 🖥️ Client-side changes:
- Updated the HUD to display the current match state (`Playing`, `Paused`, `Break`) along with the remaining time (MM:SS).
- Positioned this info centrally in the HUD for better visibility and coherence with the rest of the UI.

Here come two examples to illustrate it:
![image](https://github.com/user-attachments/assets/f27aff2c-8690-49f3-872c-085d23e86a89)
![image](https://github.com/user-attachments/assets/de69dbb8-15eb-40f1-ac8c-0be47397591e)


This lays the foundation for structured matches, pauses, and breaks — a big step toward a more game-like experience! 🚀
