### PR TITLE
feat: scale and offset state coordinates according to client window

### DIFF
--- a/src/client_loop.py
+++ b/src/client_loop.py
@@ -56,6 +56,8 @@ def get_input(keys):
         keys[pygame.K_a],
         keys[pygame.K_d],
         keys[pygame.K_SPACE],
+        pygame.display.get_window_size()[0],
+        pygame.display.get_window_size()[1],
     )
 
 

--- a/src/input.py
+++ b/src/input.py
@@ -1,7 +1,9 @@
 class Input:
-    def __init__(self, up: bool = False, down: bool = False, left: bool = False, right: bool = False, kick: bool = False) -> None:
+    def __init__(self, up: bool = False, down: bool = False, left: bool = False, right: bool = False, kick: bool = False, window_width: int = 1920, window_height: int = 1080) -> None:
         self.up: bool = up
         self.down: bool = down
         self.left: bool = left
         self.right: bool = right
         self.kick: bool = kick
+        self.window_width: int = window_width
+        self.window_height: int = window_height

--- a/src/server_loop.py
+++ b/src/server_loop.py
@@ -1,3 +1,4 @@
+import copy
 import math
 import pickle
 import pygame
@@ -10,7 +11,7 @@ def moving_circles(state):
     yield state.ball
 
 
-def step(state, clock, inputs, state_lock, send_cond, last_state_pickle):
+def step(state, clock, inputs, state_lock, send_cond, last_state):
     dt = clock.tick(60) / 1000.0  # Time since last frame
 
     with state_lock:
@@ -39,8 +40,7 @@ def step(state, clock, inputs, state_lock, send_cond, last_state_pickle):
 
         state.clock = pygame.time.get_ticks() // 1000
 
-        data = pickle.dumps(state)
-        last_state_pickle[:] = len(data).to_bytes(4, "big") + data
+        last_state[0] = copy.deepcopy(state)
 
         with send_cond:
             send_cond.notify_all()


### PR DESCRIPTION
Scales and offsets the field and circles according to the client window. I decided to fit the field both horizontally and vertically even though the original game only does it vertically.

The scaling is done on every tick. If we find it to be to taxing on the server, caching the results shouldn't be too hard.

Borders and HUD are not scaled since those are defined by the client.
HUD should probably not be scaled anyway and the client can make the borders scalable by defining their size depending on the field size / circles radius.

- Closes: #12